### PR TITLE
acl doesnt always exist

### DIFF
--- a/src/DQNEO/S3Signer/Signer.php
+++ b/src/DQNEO/S3Signer/Signer.php
@@ -15,7 +15,9 @@ class Signer
     public static function getSignedURL($httpVerb, $key, $secret, $endpoint, $bucket, $objectKey, $expires, $contentType, $acl, array $metas)
     {
         $amzHeaders = [];
-        $amzHeaders[] = "x-amz-acl:" . $_GET['acl'];
+        if (!empty($acl)) {
+            $amzHeaders[] = "x-amz-acl:" . $acl;
+        }
 
         foreach($metas as $k => $v) {
             $amzHeaders[] = sprintf("x-amz-meta-%s:%s", $k, $v);


### PR DESCRIPTION
@DQNEO 
I think `$acl` doesnot always exist.
So if `$acl` is empty, `$acl` isnt substituted for `$amzHeaders`.
