### PR TITLE
amzHeaders may be empty

### DIFF
--- a/src/DQNEO/S3Signer/Signer.php
+++ b/src/DQNEO/S3Signer/Signer.php
@@ -39,7 +39,7 @@ class Signer
         $httpVerb = "PUT";
         $contentMD5 = "";
         $canonicalizedResource = sprintf("/%s/%s", $bucket, $objectKey);
-        $canonicalizedAmzHeaders =  join("\n", $amzHeaders) . "\n";
+        $canonicalizedAmzHeaders = empty($amzHeaders) ? '' : join("\n", $amzHeaders) . "\n";
 
         $stringToSign = $httpVerb . "\n"
             . $contentMD5 . "\n"


### PR DESCRIPTION
I think `$amzHeaders` may be empty.
So if `$amzHeaders` is empty, `$canonicalizedAmzHeaders` set `''` without `\n`.
